### PR TITLE
feat: configurar CORS para permitir requisições do frontend

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,26 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  // Configuração de CORS
+  app.enableCors({
+    origin: [
+      'http://localhost:3001', // Frontend local
+      'http://localhost:3000', // Swagger local
+      'http://127.0.0.1:3001',
+      'http://127.0.0.1:3000',
+    ],
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+    allowedHeaders: [
+      'Origin',
+      'X-Requested-With',
+      'Content-Type',
+      'Accept',
+      'Authorization',
+      'Cache-Control',
+    ],
+    credentials: true,
+  });
+
   // Configuração global de validação
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
- Habilitar CORS no NestJS para permitir requisições cross-origin
- Configurar origins permitidos: localhost:3001 (frontend) e localhost:3000 (swagger)
- Permitir métodos HTTP: GET, POST, PUT, DELETE, PATCH, OPTIONS
- Configurar headers permitidos incluindo Authorization para JWT
- Habilitar credentials para cookies e autenticação
- Resolver erro de CORS policy ao consumir API do frontend