### PR TITLE
ci: update SonarCloud action and disable Quality Gate blocking

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,8 +37,8 @@ jobs:
         run: yarn test:sonar
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Necessário para PR decoration
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -52,4 +52,4 @@ jobs:
             -Dsonar.testExecutionReportPaths=test-report.xml
             -Dsonar.coverage.exclusions=**/*.spec.ts,**/*.e2e-spec.ts,src/main.ts,**/*.module.ts,**/*.dto.ts,**/*.entity.ts
             -Dsonar.cpd.exclusions=**/*.spec.ts,**/*.e2e-spec.ts,**/*.dto.ts,**/*.entity.ts,**/*.module.ts
-            -Dsonar.qualitygate.wait=${{ github.event_name != 'pull_request' }}
+            -Dsonar.qualitygate.wait=false


### PR DESCRIPTION
- Update to use sonarqube-scan-action@v5.0.0 instead of deprecated action
- Set continue-on-error: true to prevent CI from failing on Quality Gate
- Set qualitygate.wait=false to not wait for Quality Gate results
- SonarCloud will still analyze and report issues, but won't block the CI/CD pipeline

This allows the CI to pass even if Quality Gate requirements are not fully met, while still providing valuable code quality feedback.